### PR TITLE
More translations & better Geyser compatibility

### DIFF
--- a/src/main/java/com/rouesvm/servback/items/ModItemGroup.java
+++ b/src/main/java/com/rouesvm/servback/items/ModItemGroup.java
@@ -21,7 +21,7 @@ public class ModItemGroup {
     public static void initialize() {
         PolymerItemGroupUtils.registerPolymerItemGroup(Identifier.of(Main.MOD_ID + "items"), PolymerItemGroupUtils.builder()
                 .icon(() -> new ItemStack(ItemList.ENDER_BACKPACK))
-                .displayName(Text.of("Backpacks"))
+                .displayName(Text.translatable("item.serverbackpacks.gui_backpacks"))
                 .entries(((context, entries) -> addItems(entries))).build()
         );
     }

--- a/src/main/java/com/rouesvm/servback/ui/BackpackGui.java
+++ b/src/main/java/com/rouesvm/servback/ui/BackpackGui.java
@@ -22,7 +22,7 @@ public class BackpackGui extends SimpleGui {
         this.stack = stack;
         this.inventory = inventory;
 
-        this.setTitle(Text.of("Backpack"));
+        this.setTitle(Text.translatable("item.serverbackpacks.gui_backpack"));
         this.fillChest();
 
         this.open();

--- a/src/main/java/com/rouesvm/servback/ui/EnderBackpackGui.java
+++ b/src/main/java/com/rouesvm/servback/ui/EnderBackpackGui.java
@@ -18,7 +18,7 @@ public class EnderBackpackGui extends SimpleGui {
         this.stack = stack;
         this.inventory = player.getEnderChestInventory();
 
-        this.setTitle(Text.literal("Ender Backpack"));
+        this.setTitle(Text.translatable("item.serverbackpacks.gui_ender"));
         this.fillChest();
 
         this.open();

--- a/src/main/java/com/rouesvm/servback/ui/GlobalBackpackGui.java
+++ b/src/main/java/com/rouesvm/servback/ui/GlobalBackpackGui.java
@@ -23,7 +23,7 @@ public class GlobalBackpackGui extends SimpleGui {
         this.stack = stack;
         this.inventory = Main.getInventory();
 
-        this.setTitle(Text.literal("Global Backpack"));
+        this.setTitle(Text.translatable("item.serverbackpacks.gui_global"));
         this.fillChest();
 
         this.open();

--- a/src/main/resources/assets/serverbackpacks/lang/en_us.json
+++ b/src/main/resources/assets/serverbackpacks/lang/en_us.json
@@ -1,8 +1,0 @@
-{
-  "item.serverbackpacks.small" : "Small Backpack",
-  "item.serverbackpacks.medium" : "Medium Backpack",
-  "item.serverbackpacks.large" : "Large Backpack",
-
-  "item.serverbackpacks.global" : "GlobalPack",
-  "item.serverbackpacks.ender" : "EnderPack"
-}

--- a/src/main/resources/assets/serverbackpacks/lang/zh_cn.json
+++ b/src/main/resources/assets/serverbackpacks/lang/zh_cn.json
@@ -1,8 +1,0 @@
-{
-  "item.serverbackpacks.small" : "小型背包",
-  "item.serverbackpacks.medium" : "中型背包",
-  "item.serverbackpacks.large" : "大型背包",
-
-  "item.serverbackpacks.global" : "共有背包",
-  "item.serverbackpacks.ender" : "末影背包"
-}

--- a/src/main/resources/assets/serverbackpacks/lang/zh_hk.json
+++ b/src/main/resources/assets/serverbackpacks/lang/zh_hk.json
@@ -1,8 +1,0 @@
-{
-  "item.serverbackpacks.small" : "小型背包",
-  "item.serverbackpacks.medium" : "中型背包",
-  "item.serverbackpacks.large" : "大型背包",
-
-  "item.serverbackpacks.global" : "共用背包",
-  "item.serverbackpacks.ender" : "終界背包"
-}

--- a/src/main/resources/assets/serverbackpacks/lang/zh_tw.json
+++ b/src/main/resources/assets/serverbackpacks/lang/zh_tw.json
@@ -1,8 +1,0 @@
-{
-  "item.serverbackpacks.small" : "小型背包",
-  "item.serverbackpacks.medium" : "中型背包",
-  "item.serverbackpacks.large" : "大型背包",
-
-  "item.serverbackpacks.global" : "共用背包",
-  "item.serverbackpacks.ender" : "終界背包"
-}

--- a/src/main/resources/data/serverbackpacks/lang/en_us.json
+++ b/src/main/resources/data/serverbackpacks/lang/en_us.json
@@ -1,0 +1,13 @@
+{
+  "item.serverbackpacks.small" : "Small Backpack",
+  "item.serverbackpacks.medium" : "Medium Backpack",
+  "item.serverbackpacks.large" : "Large Backpack",
+
+  "item.serverbackpacks.global" : "GlobalPack",
+  "item.serverbackpacks.ender" : "EnderPack",
+
+  "item.serverbackpacks.gui_backpacks" : "Backpacks",
+  "item.serverbackpacks.gui_backpack" : "Backpack",
+  "item.serverbackpacks.gui_ender" : "Ender Backpack",
+  "item.serverbackpacks.gui_global" : "Global Backpack"
+}

--- a/src/main/resources/data/serverbackpacks/lang/zh_cn.json
+++ b/src/main/resources/data/serverbackpacks/lang/zh_cn.json
@@ -1,0 +1,13 @@
+{
+  "item.serverbackpacks.small" : "小型背包",
+  "item.serverbackpacks.medium" : "中型背包",
+  "item.serverbackpacks.large" : "大型背包",
+
+  "item.serverbackpacks.global" : "共有背包",
+  "item.serverbackpacks.ender" : "末影背包",
+
+  "item.serverbackpacks.gui_backpacks" : "背包",
+  "item.serverbackpacks.gui_backpack" : "背包",
+  "item.serverbackpacks.gui_ender" : "末影背包",
+  "item.serverbackpacks.gui_global" : "共有背包"
+}

--- a/src/main/resources/data/serverbackpacks/lang/zh_hk.json
+++ b/src/main/resources/data/serverbackpacks/lang/zh_hk.json
@@ -1,0 +1,13 @@
+{
+  "item.serverbackpacks.small" : "小型背包",
+  "item.serverbackpacks.medium" : "中型背包",
+  "item.serverbackpacks.large" : "大型背包",
+
+  "item.serverbackpacks.global" : "共用背包",
+  "item.serverbackpacks.ender" : "終界背包",
+
+  "item.serverbackpacks.gui_backpacks" : "背包",
+  "item.serverbackpacks.gui_backpack" : "背包",
+  "item.serverbackpacks.gui_ender" : "終界背包",
+  "item.serverbackpacks.gui_global" : "共用背包"
+}

--- a/src/main/resources/data/serverbackpacks/lang/zh_tw.json
+++ b/src/main/resources/data/serverbackpacks/lang/zh_tw.json
@@ -1,0 +1,13 @@
+{
+  "item.serverbackpacks.small" : "小型背包",
+  "item.serverbackpacks.medium" : "中型背包",
+  "item.serverbackpacks.large" : "大型背包",
+
+  "item.serverbackpacks.global" : "共用背包",
+  "item.serverbackpacks.ender" : "終界背包",
+
+  "item.serverbackpacks.gui_backpacks" : "背包",
+  "item.serverbackpacks.gui_backpack" : "背包",
+  "item.serverbackpacks.gui_ender" : "終界背包",
+  "item.serverbackpacks.gui_global" : "共用背包"
+}


### PR DESCRIPTION
Bedrock Edition players connected through Geyser get the internal item key as item names, for some reason moving the language files from `assets` folder to `data` folder solved this.

Before this PR:
![Clipboard - October 18, 2024 10_00 AM](https://github.com/user-attachments/assets/0746c26a-4eb0-4e19-8554-a9120af31ea3)

This doesn't completely solve backpack translation for Geyser players as it always falls back to en_us, I tried implementing [Server-Translations](https://github.com/NucleoidMC/Server-Translations) but got no luck, maybe I was just too stupid to figure it out.

Also added the GUI part in the language files as well.